### PR TITLE
compat with all major linux distros

### DIFF
--- a/51-usb-keepkey.rules
+++ b/51-usb-keepkey.rules
@@ -2,5 +2,5 @@
 # http://www.keepkey.com/
 # Put this file into /usr/lib/udev/rules.d or /etc/udev/rules.d
 
-SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0001", MODE="0666", GROUP="dialout", SYMLINK+="keepkey%n"
-KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0001", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="keepkey%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
Debian 6+, Ubuntu 13.04+ and Arch Linux do not rely on the 'dialout' group. Some older distros still use the "plugdev" group but most have been switching to a convention of using udev tags for device permissions instead.

This should avoid users having to create a group, add themseves to it, and logout/login. Plugdev group method still in place for backwards compat. Won't hurt anything.

I have been modifying this by hand for Arch and finally decided to PR it.